### PR TITLE
isolated embeddings and chatgpt models to enable Azure deployments

### DIFF
--- a/env/README.md
+++ b/env/README.md
@@ -9,6 +9,8 @@ OPENAI_API_VERSION="2023-05-15"
 AZURE_OPENAI_KEY=""
 AZURE_OPENAI_ENDPOINT="https://***.openai.azure.com/"
 AZURE_OPENAI_CHATGPT_DEPLOYMENT=""
+"AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT": "",
+"KustoConnectionString": "https://***.kusto.windows.net/vectorsearch; Fed=true; Accept=true"
 ```
 
 2. Export the environment variables from `.env` to your machine

--- a/samples/other/dotnet/csharp-inproc/CSharpInProcSamples.csproj
+++ b/samples/other/dotnet/csharp-inproc/CSharpInProcSamples.csproj
@@ -15,6 +15,9 @@
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="init.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>

--- a/samples/other/dotnet/csharp-inproc/init.txt
+++ b/samples/other/dotnet/csharp-inproc/init.txt
@@ -1,0 +1,1 @@
+another sweet embedding found only here. 

--- a/samples/other/dotnet/csharp-inproc/test.http
+++ b/samples/other/dotnet/csharp-inproc/test.http
@@ -1,0 +1,8 @@
+
+
+POST http://localhost:7071/api/IngestEmail HTTP/1.1
+content-type: application/json
+
+{
+    "FilePath": "init.txt"
+}

--- a/src/WebJobs.Extensions.OpenAI/EmbeddingsAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/EmbeddingsAttribute.cs
@@ -40,6 +40,12 @@ public sealed class EmbeddingsAttribute : Attribute
     public string Model { get; set; } = "text-embedding-ada-002";
 
     /// <summary>
+    /// Gets or sets the ID of the Model or Azure Deployment to use.
+    /// </summary>
+    [AutoResolve]
+    public string EmbeddingsModel { get; set; } = Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT") ?? "text-embedding-ada-002";
+
+    /// <summary>
     /// Gets or sets the maximum number of characters to chunk the input into.
     /// </summary>
     /// <remarks>
@@ -75,7 +81,10 @@ public sealed class EmbeddingsAttribute : Attribute
     {
         using TextReader reader = this.GetTextReader();
         List<string> chunks = GetTextChunks(reader, 0, this.MaxChunkLength).ToList();
-        return new EmbeddingCreateRequest { Model = this.Model, InputAsList = chunks };
+
+        // Prefer Azure Embedding Model over the default model
+        // Embedding Deployment Id must be different than the Chat GPT Deployment Id in Azure case
+        return new EmbeddingCreateRequest { Model = this.EmbeddingsModel, InputAsList = chunks };
     }
 
     TextReader GetTextReader()

--- a/src/WebJobs.Extensions.OpenAI/OpenAIWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.OpenAI/OpenAIWebJobsBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class OpenAIWebJobsBuilderExtensions
                     settings.BaseDomain = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")!;
                     settings.ProviderType = ProviderType.Azure;
                     settings.ApiVersion = Environment.GetEnvironmentVariable("OPENAI_API_VERSION") ?? "2023-05-15";
-                    settings.DeploymentId = Environment.GetEnvironmentVariable("AZURE_OPENAI_CHATGPT_DEPLOYMENT")!;
+                    //settings.DeploymentId = Environment.GetEnvironmentVariable("AZURE_OPENAI_CHATGPT_DEPLOYMENT")!;
                 }
             }
         });

--- a/src/WebJobs.Extensions.OpenAI/Search/SemanticSearchAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Search/SemanticSearchAttribute.cs
@@ -67,7 +67,7 @@ public class SemanticSearchAttribute : Attribute
     /// This property supports binding expressions.
     /// </remarks>
     [AutoResolve]
-    public string EmbeddingsModel { get; set; } = Models.TextEmbeddingAdaV2;
+    public string EmbeddingsModel { get; set; } = Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT") ?? Models.TextEmbeddingAdaV2;
 
     /// <summary>
     /// Gets or sets the name of the Large Language Model to invoke for chat responses.
@@ -77,7 +77,7 @@ public class SemanticSearchAttribute : Attribute
     /// This property supports binding expressions.
     /// </remarks>
     [AutoResolve]
-    public string ChatModel { get; set; } = Models.ChatGpt3_5Turbo;
+    public string ChatModel { get; set; } = Environment.GetEnvironmentVariable("AZURE_OPENAI_CHATGPT_DEPLOYMENT") ?? Models.ChatGpt3_5Turbo;
 
     /// <summary>
     /// Gets or sets the system prompt to use for prompting the large language model.


### PR DESCRIPTION
Ensuring each attribute loads models for embeddings vs chatgpt separately, and trying to cut global state from extension's builder. 