### PR TITLE
.NET Isolated support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added support for text completion input bindings in .NET Isolated
+
 ## v0.3.1 - 2023/11/5
 
 ### Changes

--- a/OpenAI-Extension.sln
+++ b/OpenAI-Extension.sln
@@ -10,6 +10,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sandbox", "sandbox", "{CAEDF9E2-7B35-4889-9341-8417321A2575}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7A80B95C-AD57-4057-AED0-48629B75874F}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "misc", "misc", "{680E7714-A1E6-45F7-BC6E-E1900067FD7A}"
 	ProjectSection(SolutionItems) = preProject
@@ -34,6 +38,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "other", "other", "{4B55F637-B067-43B4-B6FC-65171654315C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpInProcSamples", "samples\other\dotnet\csharp-inproc\CSharpInProcSamples.csproj", "{C541A7B4-5F55-4575-A80B-A9D8125E0A55}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "search", "search", "{86EAF0D2-9CE7-4537-A583-C29DA28A08F1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ooproc", "ooproc", "{E6B8C0F5-9462-4A9C-AD6F-B34721BA0E51}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functions.Worker.Extensions.OpenAI", "src\Functions.Worker.Extensions.OpenAI\Functions.Worker.Extensions.OpenAI.csproj", "{EBFED369-EBBB-49F8-B2F2-236AF3063271}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpIsolatedSamples", "samples\other\dotnet\csharp-ooproc\CSharpIsolatedSamples\CSharpIsolatedSamples.csproj", "{537FD9B3-1288-461B-BEFD-8DF323A50BF1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -65,6 +77,14 @@ Global
 		{C541A7B4-5F55-4575-A80B-A9D8125E0A55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C541A7B4-5F55-4575-A80B-A9D8125E0A55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C541A7B4-5F55-4575-A80B-A9D8125E0A55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBFED369-EBBB-49F8-B2F2-236AF3063271}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBFED369-EBBB-49F8-B2F2-236AF3063271}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBFED369-EBBB-49F8-B2F2-236AF3063271}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBFED369-EBBB-49F8-B2F2-236AF3063271}.Release|Any CPU.Build.0 = Release|Any CPU
+		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -78,6 +98,10 @@ Global
 		{B0F02F06-9124-4A91-9685-824C55E698BD} = {B99948E2-9853-4D9C-B784-19C2503CDA8B}
 		{4B55F637-B067-43B4-B6FC-65171654315C} = {865C9FB5-1043-47BE-B650-25A2B42030A3}
 		{C541A7B4-5F55-4575-A80B-A9D8125E0A55} = {4B55F637-B067-43B4-B6FC-65171654315C}
+		{86EAF0D2-9CE7-4537-A583-C29DA28A08F1} = {865C9FB5-1043-47BE-B650-25A2B42030A3}
+		{E6B8C0F5-9462-4A9C-AD6F-B34721BA0E51} = {86EAF0D2-9CE7-4537-A583-C29DA28A08F1}
+		{EBFED369-EBBB-49F8-B2F2-236AF3063271} = {7A80B95C-AD57-4057-AED0-48629B75874F}
+		{537FD9B3-1288-461B-BEFD-8DF323A50BF1} = {4B55F637-B067-43B4-B6FC-65171654315C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {05A7A679-3A53-45B5-AE93-4313655E127D}

--- a/samples/chat/csharp-inproc/ChatBotSample.csproj
+++ b/samples/chat/csharp-inproc/ChatBotSample.csproj
@@ -12,6 +12,9 @@
     <ProjectReference Include="..\..\..\src\WebJobs.Extensions.OpenAI\WebJobs.Extensions.OpenAI.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="7.0.*" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/CSharpIsolatedSamples.csproj
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/CSharpIsolatedSamples.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\src\Functions.Worker.Extensions.OpenAI\Functions.Worker.Extensions.OpenAI.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+</Project>

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/Program.cs
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/Program.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Extensions.Hosting;
+
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .Build();
+
+host.Run();

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/TextCompletions.cs
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/TextCompletions.cs
@@ -1,0 +1,50 @@
+using Functions.Worker.Extensions.OpenAI;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using OpenAI.ObjectModels.ResponseModels;
+
+namespace CSharpIsolatedSamples;
+
+/// <summary>
+/// These samples show how to use the OpenAI Completions APIs. For more details on the Completions APIs, see
+/// https://platform.openai.com/docs/guides/completion.
+/// </summary>
+public static class TextCompletions
+{
+    /// <summary>
+    /// This sample demonstrates the "templating" pattern, where the function takes a parameter
+    /// and embeds it into a text prompt, which is then sent to the OpenAI completions API.
+    /// </summary>
+    [Function(nameof(WhoIs))]
+    public static string WhoIs(
+        [HttpTrigger(AuthorizationLevel.Function, Route = "whois/{name}")] HttpRequestData req,
+        [TextCompletion("Who is {name}?")] CompletionCreateResponse response)
+    {
+        return response.Choices[0].Text;
+    }
+
+    /// <summary>
+    /// This sample takes a prompt as input, sends it directly to the OpenAI completions API, and results the 
+    /// response as the output.
+    /// </summary>
+    [Function(nameof(GenericCompletion))]
+    public static IActionResult GenericCompletion(
+        [HttpTrigger(AuthorizationLevel.Function, "post")] PromptPayload payload,
+        [TextCompletion("{Prompt}", Model = "text-davinci-003")] CompletionCreateResponse response,
+        ILogger log)
+    {
+        if (!response.Successful)
+        {
+            Error error = response.Error ?? new Error() { MessageObject = "OpenAI returned an unspecified error" };
+            return new ObjectResult(error) { StatusCode = 500 };
+        }
+
+        log.LogInformation("Prompt = {prompt}, Response = {response}", payload.Prompt, response);
+        string text = response.Choices[0].Text;
+        return new OkObjectResult(text);
+    }
+
+    public record PromptPayload(string Prompt);
+}

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/TextCompletions.cs
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/TextCompletions.cs
@@ -20,7 +20,7 @@ public static class TextCompletions
     [Function(nameof(WhoIs))]
     public static string WhoIs(
         [HttpTrigger(AuthorizationLevel.Function, Route = "whois/{name}")] HttpRequestData req,
-        [TextCompletion("Who is {name}?")] CompletionCreateResponse response)
+        [TextCompletionInput("Who is {name}?")] CompletionCreateResponse response)
     {
         return response.Choices[0].Text;
     }
@@ -32,7 +32,7 @@ public static class TextCompletions
     [Function(nameof(GenericCompletion))]
     public static IActionResult GenericCompletion(
         [HttpTrigger(AuthorizationLevel.Function, "post")] PromptPayload payload,
-        [TextCompletion("{Prompt}", Model = "text-davinci-003")] CompletionCreateResponse response,
+        [TextCompletionInput("{Prompt}", Model = "text-davinci-003")] CompletionCreateResponse response,
         ILogger log)
     {
         if (!response.Successful)

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/host.json
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/host.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            },
+            "enableLiveMetricsFilters": true
+        }
+    }
+}

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/local.settings.json
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/cgillum/azure-functions-openai-extension</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
@@ -20,7 +21,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
@@ -30,7 +31,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All" />
+    <!--<PackageReference Include="LocalNuGet" Version="1.0.0" />-->
   </ItemGroup>
 
   <!-- https://aka.ms/nuget/authoring-best-practices/readme -->

--- a/src/Functions.Worker.Extensions.OpenAI/Functions.Worker.Extensions.OpenAI.csproj
+++ b/src/Functions.Worker.Extensions.OpenAI/Functions.Worker.Extensions.OpenAI.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <!-- TODO: Keep in sync with WebJobs package -->
+  <ItemGroup>
+    <PackageReference Include="Betalgo.OpenAI" Version="7.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Functions.Worker.Extensions.OpenAI/TextCompletionAttribute.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/TextCompletionAttribute.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using OpenAI.ObjectModels.RequestModels;
+
+// TODO: Move this somewhere else
+[assembly: ExtensionInformation("CGillum.WebJobs.Extensions.OpenAI", "0.3.1-alpha")]
+
+
+namespace Functions.Worker.Extensions.OpenAI;
+
+/// <summary>
+/// Input binding attribute for capturing OpenAI completions in function executions.
+/// </summary>
+public sealed class TextCompletionAttribute : InputBindingAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextCompletionAttribute"/> class with the specified text prompt.
+    /// </summary>
+    /// <param name="prompt">The prompt to generate completions for, encoded as a string.</param>
+    public TextCompletionAttribute(string prompt)
+    {
+        this.Prompt = prompt ?? throw new ArgumentNullException(nameof(prompt));
+    }
+
+    /// <summary>
+    /// Gets or sets the prompt to generate completions for, encoded as a string.
+    /// </summary>
+    public string Prompt { get; }
+
+    /// <summary>
+    /// Gets or sets the ID of the model to use.
+    /// </summary>
+    public string Model { get; set; } = "text-davinci-003";
+
+    /// <summary>
+    /// Gets or sets the sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output
+    /// more random, while lower values like 0.2 will make it more focused and deterministic.
+    /// </summary>
+    /// <remarks>
+    /// It's generally recommend to use this or <see cref="this.TopP"/> but not both.
+    /// </remarks>
+    public string? Temperature { get; set; } = "0.5";
+
+    /// <summary>
+    /// Gets or sets an alternative to sampling with temperature, called nucleus sampling, where the model considers
+    /// the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10%
+    /// probability mass are considered.
+    /// </summary>
+    /// <remarks>
+    /// It's generally recommend to use this or <see cref="this.Temperature"/> but not both.
+    /// </remarks>
+    public string? TopP { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of tokens to generate in the completion.
+    /// </summary>
+    /// <remarks>
+    /// The token count of your prompt plus max_tokens cannot exceed the model's context length.
+    /// Most models have a context length of 2048 tokens (except for the newest models, which support 4096).
+    /// </remarks>
+    public string? MaxTokens { get; set; } = "100";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the binding should throw if there is an error calling the OpenAI
+    /// endpoint.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <c>true</c>. Set this to <c>false</c> to handle errors manually in the function code.
+    /// </remarks>
+    public bool ThrowOnError { get; set; } = true;
+
+    internal CompletionCreateRequest BuildRequest()
+    {
+        CompletionCreateRequest request = new()
+        {
+            Prompt = this.Prompt
+        };
+
+        if (this.Model is not null)
+        {
+            request.Model = this.Model;
+        }
+
+        if (int.TryParse(this.MaxTokens, out int maxTokens))
+        {
+            request.MaxTokens = maxTokens;
+        }
+
+        if (float.TryParse(this.Temperature, out float temperature))
+        {
+            request.Temperature = temperature;
+        }
+
+        if (float.TryParse(this.TopP, out float topP))
+        {
+            request.TopP = topP;
+        }
+
+        return request;
+    }
+}

--- a/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
@@ -13,13 +13,13 @@ namespace Functions.Worker.Extensions.OpenAI;
 /// <summary>
 /// Input binding attribute for capturing OpenAI completions in function executions.
 /// </summary>
-public sealed class TextCompletionAttribute : InputBindingAttribute
+public sealed class TextCompletionInputAttribute : InputBindingAttribute
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="TextCompletionAttribute"/> class with the specified text prompt.
+    /// Initializes a new instance of the <see cref="TextCompletionInputAttribute"/> class with the specified text prompt.
     /// </summary>
     /// <param name="prompt">The prompt to generate completions for, encoded as a string.</param>
-    public TextCompletionAttribute(string prompt)
+    public TextCompletionInputAttribute(string prompt)
     {
         this.Prompt = prompt ?? throw new ArgumentNullException(nameof(prompt));
     }

--- a/src/WebJobs.Extensions.OpenAI/EmbeddingsConverter.cs
+++ b/src/WebJobs.Extensions.OpenAI/EmbeddingsConverter.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using OpenAI.Interfaces;
 using OpenAI.ObjectModels.RequestModels;
 using OpenAI.ObjectModels.ResponseModels;
@@ -38,7 +35,7 @@ class EmbeddingsConverter :
         CancellationToken cancellationToken)
     {
         EmbeddingsContext response = await this.ConvertCoreAsync(input, cancellationToken);
-        return JsonSerializer.Serialize(response);
+        return JsonConvert.SerializeObject(response);
     }
 
     async Task<EmbeddingsContext> ConvertCoreAsync(

--- a/src/WebJobs.Extensions.OpenAI/TextCompletionConverter.cs
+++ b/src/WebJobs.Extensions.OpenAI/TextCompletionConverter.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using OpenAI.Interfaces;
 using OpenAI.ObjectModels.RequestModels;
 using OpenAI.ObjectModels.ResponseModels;
@@ -40,7 +37,7 @@ class TextCompletionConverter :
         CancellationToken cancellationToken)
     {
         CompletionCreateResponse response = await this.ConvertCoreAsync(attribute, cancellationToken);
-        return JsonSerializer.Serialize(response);
+        return JsonConvert.SerializeObject(response);
     }
 
     async Task<CompletionCreateResponse> ConvertCoreAsync(


### PR DESCRIPTION
Resolves #12 

Initial PR only includes the text completion binding, which is the easiest to test.

Also includes a .NET Isolated sample project in the "other" sample category.

Unfortunately, the use of System.Text.Json in the WebJobs assembly breaks the scenario, so I had to replace it with Newtonsoft and create a new local nuget package. The fact that I had to make a change to the WebJobs assembly will make it harder to test locally. Basically, to test this, you'll need to build the WebJobs assembly locally, install it into a local nuget source on your file system, and register that source globally on your machine in order for the .NET Isolated SDK to be able to resolve it.

**EDIT**: Published 0.3.1-alpha version of WebJobs packages to nuget.org, so now the CI is happy and devs don't need to deploy anything local.