### PR TITLE
Replace WebJobs usage of System.Text.Json with Newtonsoft.Json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3.0 - Unreleased
+## v0.3.1 - 2023/11/5
+
+### Changes
+
+- Replace System.Text.Json usage with Newtonsoft.Json (unblocks .NET Isolated support)
+
+## v0.3.0
 
 ### Added
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/src/WebJobs.Extensions.OpenAI/EmbeddingsConverter.cs
+++ b/src/WebJobs.Extensions.OpenAI/EmbeddingsConverter.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using OpenAI.Interfaces;
 using OpenAI.ObjectModels.RequestModels;
 using OpenAI.ObjectModels.ResponseModels;
@@ -38,7 +38,7 @@ class EmbeddingsConverter :
         CancellationToken cancellationToken)
     {
         EmbeddingsContext response = await this.ConvertCoreAsync(input, cancellationToken);
-        return JsonSerializer.Serialize(response);
+        return JsonConvert.SerializeObject(response);
     }
 
     async Task<EmbeddingsContext> ConvertCoreAsync(

--- a/src/WebJobs.Extensions.OpenAI/TextCompletionConverter.cs
+++ b/src/WebJobs.Extensions.OpenAI/TextCompletionConverter.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using OpenAI.Interfaces;
 using OpenAI.ObjectModels.RequestModels;
 using OpenAI.ObjectModels.ResponseModels;
@@ -40,7 +40,7 @@ class TextCompletionConverter :
         CancellationToken cancellationToken)
     {
         CompletionCreateResponse response = await this.ConvertCoreAsync(attribute, cancellationToken);
-        return JsonSerializer.Serialize(response);
+        return JsonConvert.SerializeObject(response);
     }
 
     async Task<CompletionCreateResponse> ConvertCoreAsync(


### PR DESCRIPTION
When adding support for .NET Isolated in another branch, the use of System.Text.Json was causing assembly load issues in the Functions host. The exact reason isn't clear, but switching to Newtonsoft.Json seemed to fix the issue. Making that change into a 0.3.1 release so that the .NET Isolated PR can reference it from nuget.org.