### PR TITLE
Support for chat bot model selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,22 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+
+    - name: Configure NuGet
+      run: dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json
+
     - name: Restore dependencies
       run: dotnet restore
+
     - name: Main Build
       run: dotnet build --configuration $config --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER
+
     - name: Docker Build - Chat Bot Sample
       run: docker build -f samples/chat/csharp-inproc/Dockerfile -t openai-func-sample-csharp-inproc .
+
     - name: Docker Run - Azurite
       run: docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite
+
     - name: Docker Run - Chat Bot Sample
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -39,15 +47,20 @@ jobs:
             --env OPENAI_API_KEY=$OPENAI_API_KEY \
             --env 'AzureWebJobsStorage=UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://host.docker.internal' \
             openai-func-sample-csharp-inproc
+
     - name: Sleep for 10 seconds
       run: sleep 10s
+
     - name: E2E Test - Chat Bot Sample
       run: dotnet test --configuration $config --no-build --verbosity normal
+
     - name: Print Docker Logs - Chat Bot Sample
       run: docker logs openai-func-sample-csharp-inproc
       if: always()
+
     - name: Pack
       run: dotnet pack --configuration $config --no-build --output artifacts
+
     - name: Upload
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Configure NuGet
-      run: dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json
+    - name: Configure NuGet for Worker build
+      run: cd /tmp && dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Configure NuGet for Worker build
-      run: cd /tmp && dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json
+      run: cd /tmp && dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json --name myget.org
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - name: Configure NuGet for Worker build
-      run: cd /tmp && dotnet nuget add source https://www.myget.org/F/azure-appservice/api/v3/index.json --name myget.org
-
     - name: Restore dependencies
       run: dotnet restore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.4.0 - 2023/11/14
 
 ### Added
 
 - Added support for text completion input bindings in .NET Isolated
+- Added support for configuring the model used by chat bots
+
+### Changes
+
+- Updated [Betalgo.OpenAI](https://www.nuget.org/packages/Betalgo.OpenAI) from 7.3.0 to 7.4.0.
+  - Fixes bad error handling behavior that was introduced in 7.3.0.
 
 ## v0.3.1 - 2023/11/5
 

--- a/OpenAI-Extension.sln
+++ b/OpenAI-Extension.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "misc", "misc", "{680E7714-A
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		CHANGELOG.md = CHANGELOG.md
+		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -45,7 +46,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ooproc", "ooproc", "{E6B8C0
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functions.Worker.Extensions.OpenAI", "src\Functions.Worker.Extensions.OpenAI\Functions.Worker.Extensions.OpenAI.csproj", "{EBFED369-EBBB-49F8-B2F2-236AF3063271}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpIsolatedSamples", "samples\other\dotnet\csharp-ooproc\CSharpIsolatedSamples\CSharpIsolatedSamples.csproj", "{537FD9B3-1288-461B-BEFD-8DF323A50BF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpIsolatedSamples", "samples\other\dotnet\csharp-ooproc\CSharpIsolatedSamples\CSharpIsolatedSamples.csproj", "{537FD9B3-1288-461B-BEFD-8DF323A50BF1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="azure-appservice" value="https://www.myget.org/F/azure-appservice/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="azure-appservice" value="https://www.myget.org/F/azure-appservice/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/samples/chat/csharp-inproc/ChatBot.cs
+++ b/samples/chat/csharp-inproc/ChatBot.cs
@@ -42,7 +42,7 @@ public static class ChatBot
     public static async Task<IActionResult> PostUserResponse(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "chats/{chatId}")] HttpRequest req,
         string chatId,
-        [ChatBotPost("{chatId}", Model = "gpt-3.5-turbo")] ICollector<ChatBotPostRequest> newMessages)
+        [ChatBotPost("{chatId}")] ICollector<ChatBotPostRequest> newMessages)
     {
         string userMessage = await req.ReadAsStringAsync();
         if (string.IsNullOrEmpty(userMessage))

--- a/samples/chat/csharp-inproc/ChatBot.cs
+++ b/samples/chat/csharp-inproc/ChatBot.cs
@@ -42,7 +42,7 @@ public static class ChatBot
     public static async Task<IActionResult> PostUserResponse(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "chats/{chatId}")] HttpRequest req,
         string chatId,
-        [ChatBotPost("{chatId}")] ICollector<ChatBotPostRequest> newMessages)
+        [ChatBotPost("{chatId}", Model = "gpt-3.5-turbo")] ICollector<ChatBotPostRequest> newMessages)
     {
         string userMessage = await req.ReadAsStringAsync();
         if (string.IsNullOrEmpty(userMessage))

--- a/samples/chat/csharp-inproc/ChatBotSample.csproj
+++ b/samples/chat/csharp-inproc/ChatBotSample.csproj
@@ -5,6 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\demo.http" Link="demo.http" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All" />
-    <PackageReference Include="LocalNuGet" Version="1.0.0" />
   </ItemGroup>
 
   <!-- https://aka.ms/nuget/authoring-best-practices/readme -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,8 +20,8 @@
     <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>3</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>4</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All" />
-    <!--<PackageReference Include="LocalNuGet" Version="1.0.0" />-->
+    <PackageReference Include="LocalNuGet" Version="1.0.0" />
   </ItemGroup>
 
   <!-- https://aka.ms/nuget/authoring-best-practices/readme -->

--- a/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
-using OpenAI.ObjectModels.RequestModels;
+
 
 // TODO: Move this somewhere else
-[assembly: ExtensionInformation("CGillum.WebJobs.Extensions.OpenAI", "0.3.1-alpha")]
+[assembly: ExtensionInformation("CGillum.WebJobs.Extensions.OpenAI", "0.4.0-alpha")]
 
 
 namespace Functions.Worker.Extensions.OpenAI;
@@ -70,34 +70,4 @@ public sealed class TextCompletionInputAttribute : InputBindingAttribute
     /// The default value is <c>true</c>. Set this to <c>false</c> to handle errors manually in the function code.
     /// </remarks>
     public bool ThrowOnError { get; set; } = true;
-
-    internal CompletionCreateRequest BuildRequest()
-    {
-        CompletionCreateRequest request = new()
-        {
-            Prompt = this.Prompt
-        };
-
-        if (this.Model is not null)
-        {
-            request.Model = this.Model;
-        }
-
-        if (int.TryParse(this.MaxTokens, out int maxTokens))
-        {
-            request.MaxTokens = maxTokens;
-        }
-
-        if (float.TryParse(this.Temperature, out float temperature))
-        {
-            request.Temperature = temperature;
-        }
-
-        if (float.TryParse(this.TopP, out float topP))
-        {
-            request.TopP = topP;
-        }
-
-        return request;
-    }
 }

--- a/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
@@ -5,7 +5,7 @@ using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 
 // TODO: Move this somewhere else
-[assembly: ExtensionInformation("CGillum.WebJobs.Extensions.OpenAI", "0.4.0-alpha")]
+[assembly: ExtensionInformation("CGillum.WebJobs.Extensions.OpenAI", "0.3.1-alpha")]
 
 
 namespace Functions.Worker.Extensions.OpenAI;

--- a/src/WebJobs.Extensions.OpenAI/Agents/ChatBotBindingConverter.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/ChatBotBindingConverter.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
 
 namespace WebJobs.Extensions.OpenAI.Agents;
 
@@ -27,7 +23,7 @@ class ChatBotBindingConverter :
         this.logger = loggerFactory.CreateLogger<ChatBotBindingConverter>();
     }
 
-    public IAsyncCollector<ChatBotCreateRequest> Convert(ChatBotCreateAttribute input)
+    public IAsyncCollector<ChatBotCreateRequest> Convert(ChatBotCreateAttribute attribute)
     {
         return new ChatBotCreateCollector(this.chatBotService, this.logger);
     }
@@ -126,15 +122,17 @@ class ChatBotBindingConverter :
             this.attribute = attribute;
         }
 
-        public Task AddAsync(ChatBotPostRequest item, CancellationToken cancellationToken = default)
+        public Task AddAsync(ChatBotPostRequest request, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrEmpty(item.Id))
+            if (string.IsNullOrEmpty(request.Id))
             {
-                item.Id = this.attribute.Id;
+                request.Id = this.attribute.Id;
             }
 
-            this.logger.LogInformation("Posting message to chat bot '{Id}': {Text}", item.Id, item.UserMessage);
-            return this.chatService.PostMessageAsync(item, cancellationToken);
+            request.Model = this.attribute.Model;
+
+            this.logger.LogInformation("Posting message to chat bot '{Id}': {Text}", request.Id, request.UserMessage);
+            return this.chatService.PostMessageAsync(request, cancellationToken);
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default)

--- a/src/WebJobs.Extensions.OpenAI/Agents/ChatBotEntity.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/ChatBotEntity.cs
@@ -110,7 +110,7 @@ class ChatBotEntity : IChatBotEntity
         ChatCompletionCreateRequest chatRequest = new()
         {
             Messages = this.State.ChatMessages.Select(item => item.Message).ToList(),
-            Model = Models.Gpt_3_5_Turbo,
+            Model = request.Model ?? Models.Gpt_3_5_Turbo,
         };
 
         IOpenAIService service = this.openAIServiceProvider.GetService(chatRequest.Model);
@@ -119,8 +119,8 @@ class ChatBotEntity : IChatBotEntity
         {
             // Throwing an exception will cause the entity to abort the current operation.
             // Any changes to the entity state will be discarded.
-            Error error = response.Error ?? new Error() { MessageObject = "Unspecified error" };
-            throw new ApplicationException($"The {chatRequest.Model} engine returned an error: {error}");
+            Error error = response.Error ?? new Error() { Code = "Unspecified", MessageObject = "Unspecified error" };
+            throw new ApplicationException($"The OpenAI {chatRequest.Model} engine returned a '{error.Code}' error: {error.Message}");
         }
 
         // We don't normally expect more than one message, but just in case we get multiple messages,

--- a/src/WebJobs.Extensions.OpenAI/Agents/ChatBotPostAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/ChatBotPostAttribute.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Azure.WebJobs.Description;
 
 namespace WebJobs.Extensions.OpenAI.Agents;
@@ -20,9 +19,20 @@ public class ChatBotPostAttribute : Attribute
     /// </summary>
     [AutoResolve]
     public string Id { get; }
+
+    /// <summary>
+    /// Gets or sets the OpenAI chat model to use.
+    /// </summary>
+    /// <remarks>
+    /// When using Azure OpenAI, then should be the name of the model <em>deployment</em>.
+    /// </remarks>
+    [AutoResolve]
+    public string? Model { get; set; }
 }
 
 public record ChatBotPostRequest(string UserMessage)
 {
     public string Id { get; set; } = string.Empty;
+
+    public string? Model { get; set; }
 }

--- a/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
+++ b/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
@@ -3,12 +3,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.*" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.10.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.*" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.0-preview" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Betalgo.OpenAI" Version="7.3.0" />
+    <PackageReference Include="Betalgo.OpenAI" Version="7.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
+++ b/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.*" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.*" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.0-preview" />
   </ItemGroup>
 


### PR DESCRIPTION
Previously, it wasn't possible to choose a model when using chat bots. Now you can! This has been tested with Azure OpenAI.

This PR also increases the `Betalgo.OpenAI` to 7.4.0, which fixes some error handling issues in the previous 7.3.0 release.