### PR TITLE
Assistants - chat bots with skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 - 2023/12/16
+
+### Added
+
+- Assistants: chat bots with skills via new `assistantSkillTrigger` trigger
+
 ## v0.4.0 - 2023/11/14
 
 ### Added

--- a/OpenAI-Extension.sln
+++ b/OpenAI-Extension.sln
@@ -48,6 +48,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functions.Worker.Extensions
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpIsolatedSamples", "samples\other\dotnet\csharp-ooproc\CSharpIsolatedSamples\CSharpIsolatedSamples.csproj", "{537FD9B3-1288-461B-BEFD-8DF323A50BF1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assistant", "assistant", "{2D012B0E-6946-4707-830C-F73AB5C7B37D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssistantSample", "samples\assistant\csharp-inproc\AssistantSample.csproj", "{A6A8CF51-CADB-4759-904F-961BD8C516D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +90,10 @@ Global
 		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{537FD9B3-1288-461B-BEFD-8DF323A50BF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6A8CF51-CADB-4759-904F-961BD8C516D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6A8CF51-CADB-4759-904F-961BD8C516D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6A8CF51-CADB-4759-904F-961BD8C516D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6A8CF51-CADB-4759-904F-961BD8C516D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -103,6 +111,8 @@ Global
 		{E6B8C0F5-9462-4A9C-AD6F-B34721BA0E51} = {86EAF0D2-9CE7-4537-A583-C29DA28A08F1}
 		{EBFED369-EBBB-49F8-B2F2-236AF3063271} = {7A80B95C-AD57-4057-AED0-48629B75874F}
 		{537FD9B3-1288-461B-BEFD-8DF323A50BF1} = {4B55F637-B067-43B4-B6FC-65171654315C}
+		{2D012B0E-6946-4707-830C-F73AB5C7B37D} = {865C9FB5-1043-47BE-B650-25A2B42030A3}
+		{A6A8CF51-CADB-4759-904F-961BD8C516D7} = {2D012B0E-6946-4707-830C-F73AB5C7B37D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {05A7A679-3A53-45B5-AE93-4313655E127D}

--- a/OpenAI-Extension.sln
+++ b/OpenAI-Extension.sln
@@ -50,7 +50,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpIsolatedSamples", "sa
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assistant", "assistant", "{2D012B0E-6946-4707-830C-F73AB5C7B37D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssistantSample", "samples\assistant\csharp-inproc\AssistantSample.csproj", "{A6A8CF51-CADB-4759-904F-961BD8C516D7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssistantSample", "samples\assistant\csharp-inproc\AssistantSample.csproj", "{A6A8CF51-CADB-4759-904F-961BD8C516D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following features are currently available. More features will be slowly add
 
 * [Text completions](#text-completion-input-binding)
 * [Chat bots](#chat-bots)
+* [Assistants](#assistants)
 * [Embeddings generators](#embeddings-generator)
 * [Semantic search](#semantic-search)
 
@@ -106,6 +107,47 @@ There are three bindings you can use to interact with the chat bot:
 1. The `chatBotQuery` input binding fetches the chat bot history and passes it to the function.
 
 You can find samples in multiple languages with instructions [in the chat samples directory](./samples/chat/).
+
+### Assistants
+
+Assistants build on top of the chat bot functionality to provide chat bots with custom skills defined as functions.
+This internally uses the [function calling](https://platform.openai.com/docs/guides/function-calling) feature of OpenAIs GPT models to select which functions to invoke and when.
+
+You can define functions that can be triggered by chat bots by using the `assistantSkillTrigger` trigger binding.
+These functions are invoked by the extension when a chat bot signals that it would like to invoke a function in response to a user prompt.
+
+The name of the function, the description provided by the trigger, and the parameter name are all hints that the underlying language model use to determine when and how to invoke an assistant function.
+
+#### [C# example](./samples/assistant/csharp-inproc)
+
+```csharp
+public class AssistantSkills
+{
+    readonly ITodoManager todoManager;
+
+    // This constructor is called by the Azure Functions runtime's dependency injection container.
+    public AssistantSkills(ITodoManager todoManager)
+    {
+        this.todoManager = todoManager ?? throw new ArgumentNullException(nameof(todoManager));
+    }
+
+    // Called by the assistant to create new todo tasks.
+    [FunctionName(nameof(AddTodo))]
+    public Task AddTodo([AssistantSkillTrigger("Create a new todo task")] string taskDescription)
+    {
+        string todoId = Guid.NewGuid().ToString()[..6];
+        return this.todoManager.AddTodoAsync(new TodoItem(todoId, taskDescription));
+    }
+
+    // Called by the assistant to fetch the list of previously created todo tasks.
+    [FunctionName(nameof(GetTodos))]
+    public Task<IReadOnlyList<TodoItem>> GetTodos(
+        [AssistantSkillTrigger("Fetch the list of previously created todo tasks")] object inputIgnored)
+    {
+        return this.todoManager.GetTodosAsync();
+    }
+}
+```
 
 ### Embeddings Generator
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ public class AssistantSkills
 }
 ```
 
+You can find samples with instructions [in the assistant samples directory](./samples/assistant/).
+
 ### Embeddings Generator
 
 OpenAI's [text embeddings](https://platform.openai.com/docs/guides/embeddings) measure the relatedness of text strings. Embeddings are commonly used for:

--- a/samples/assistant/README.md
+++ b/samples/assistant/README.md
@@ -1,0 +1,223 @@
+# Assistants
+
+This sample demonstrates how to build an AI assistant chatbot with custom skills using Azure Functions and a local build of the experimental OpenAI extension.
+It builds upon the concepts [chatbot](../chatbot) sample, which demonstrates how to create a simple chatbot.
+
+## Introduction
+
+AI assistants are chat bots that can be configured with custom skills. Custom skills are implemented using the `assistantSkillTrigger` binding.
+Custom skills are useful ways to extend the functionality of an AI assistant. For example, you can create a custom skill that saves a todo item
+to a database, or a custom skill that queries a database for a list of todo items. In both cases, the skills are defined in your app and any 
+the language model doesn't need to know anything about the skill implementation, making it useful for interacting with private data.
+
+This OpenAI extension internally uses the [function calling](https://platform.openai.com/docs/guides/function-calling) functionality available in
+`gpt-3.5-turbo` and `gpt-4` models to implement assistant skills.
+
+## Defining skills
+
+You can define a skill by creating a function that uses the `AssistantSkillTrigger` binding. The following C# in-proc example shows a skill that adds a todo item to a database:
+
+```csharp
+[FunctionName(nameof(AddTodo))]
+public Task AddTodo([AssistantSkillTrigger("Create a new todo task")] string taskDescription)
+{
+    string todoId = Guid.NewGuid().ToString()[..6];
+    return this.todoManager.AddTodoAsync(new TodoItem(todoId, taskDescription));
+}
+```
+
+The `AssistantSkillTrigger` attribute requires a `FunctionDescription` string value, which is text describing what the function does. This is critical
+for the AI assistant to be able to invoke the skill at the right time. The name of the function parameter (e.g., `taskDescription`) is also an important
+hint to the AI assistant about what kind of information to provide to the skill.
+
+> **NOTE:** The `AssistantSkillTrigger` attribute only supports primitive types as function parameters, such as `string`, `int`, `bool`, etc. Function return values can be of any JSON-serializable type.
+
+Any function that uses the `AssistantSkillTrigger` binding will be automatically registered as a skill that can be invoked by any AI assistant.
+The assistant will invoke a skill function whenever it decides to do so to satisfy a user prompt, and will provide function parameters based on
+the context of the conversation. The skill function can then return a response to the assistant, which will be used to satisfy the user prompt.
+
+## Prerequisites
+
+The sample is available in the following language stacks:
+
+* [C# on the in-process worker](csharp-inproc)
+
+> **NOTE:** This sample is unfortunately incompatible with the .NET "Isolated" out-of-process worker.
+Issue [#21](https://github.com/cgillum/azure-functions-openai-extension/issues/21) is currently tracking this support gap.
+
+You must have the following installed on your local machine in order to run these samples.
+
+* [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) or newer
+* [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=v4%2Cwindows%2Ccsharp%2Cportal%2Cbash) v4.0.5455 or newer
+* An [OpenAI API key](https://platform.openai.com/account/api-keys) saved into a `OPENAI_API_KEY` environment variable
+* Azure Storage emulator such as [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) running in the background
+
+If you want to run the sample with Cosmos DB, then you must also have the following installed:
+
+* [Azure Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator) or a connection string to a real Azure Cosmos DB resource
+
+## Running the sample
+
+1. Clone this repo and navigate to the sample folder.
+1. Use a terminal window to navigate to the sample directory (e.g. `cd samples/assistant/csharp-inproc`)
+1. Run `func start --port 7168` to build and run the sample function app
+
+    If successful, you should see the following output from the `func` command:
+
+    ```plaintext
+    Functions:
+
+        CreateAssistant: [PUT] http://localhost:7168/api/assistants/{assistantId}
+
+        GetChatState: [GET] http://localhost:7168/api/assistants/{assistantId}
+
+        PostUserQuery: [POST] http://localhost:7168/api/assistants/{assistantId}
+
+        AddTodo: assistantSkillTrigger
+
+        GetTodos: assistantSkillTrigger
+
+        OpenAI::ChatBotEntity: entityTrigger
+    ```
+
+    > **NOTE:** The `OpenAI::ChatBotEntity` function is a special "built-in" function that is automatically added by the OpenAI extension. It's not defined by the sample project.
+
+1. Use an HTTP client tool to send a `PUT` request to the `CreateAssistant` function. The following is an example request:
+
+    ```http
+    PUT http://localhost:7168/api/assistants/assistant123
+    ```
+    
+    > **NOTE:** The `assistant123` value is the unique ID of the assistant. You can use any value you like, but it must be unique and must be used consistently in all subsequent requests.
+
+    > **NOTE:** All the HTTP requests in this sample can also be found in the [demo.http](demo.http) file, which can be opened and run in most IDEs.
+
+    The HTTP response should look something like the following:
+
+    ```json
+    {"assistantId":"assistant123"}
+    ```
+
+    You should also see some relevant log output in the terminal window where the app is running.
+
+    The AI assistant is now created and ready to receive prompts.
+
+1. Ask the assistant to create a todo item by sending a `POST` request to the `PostUserQuery` function to send a prompt to the assistant. The following is an example request:
+
+	```http
+    POST http://localhost:7168/api/assistants/assistant123
+    Content-Type: text/plain
+
+    Remind me to call my dad
+    ```
+
+    The response should be an HTTP 202, indicating that the request was accepted. You should also see some relevant log output in the terminal window where the app is running.
+
+	> **NOTE:** The AI assistant runs asynchronously in the background, so it doesn't respond immediately to prompts.  You should wait for about 10 seconds before sending subsequent messages to the assistant to give it time to finish processing the previous prompt.
+
+	
+	In the function log output, you should observe that the `AddTodo` function was triggered. This function is a custom skill that was automatically registered with the assistant when the app was started.
+
+1. Ask the assistant to create another todo item using another `POST` request to the `PostUserQuery` function. The following is an example request:
+
+	```http
+	POST http://localhost:7168/api/assistants/assistant123
+	Content-Type: text/plain
+
+	Oh, and to take out the trash
+	```
+    
+	The AI assistant remembers the context from the chat, so it knows that you're still talking about todo items, even if your prompt doesn't mention this explicitly.
+
+1. If you're running the sample with Cosmos DB persistence configured, then you can use the Cosmos DB Data Explorer to view the documents in the `my-todos` collection in the `testdb` database. You should see two documents, one for each todo item that the assistant created.
+
+1. Ask the assistant to list your todo items by sending a `POST` request to the `PostUserQuery` function. The following is an example request:
+
+  	```http
+	POST http://localhost:7168/api/assistants/assistant123
+	Content-Type: text/plain
+
+	What do I need to do today?
+	```
+
+	The response should be an HTTP 202, indicating that the prompt was accepted. In the function log output, you should observe that the `GetTodos` function was triggered. This function is a custom skill that the assistant users to query any previously saved todos.
+
+1. Query the chat history by sending a `GET` request to the `GetChatState` function. The following is an example request:
+
+	```http
+	GET http://localhost:7168/api/assistants/assistant123?timestampUTC=2023-01-01T00:00:00Z
+	```
+
+	The response body should look something like the following:
+
+	```json
+    {
+      "id": "assistant123",
+      "exists": true,
+      "status": "Active",
+      "createdAt": "2023-11-26T00:40:56.7864809Z",
+      "lastUpdatedAt": "2023-11-26T00:41:21.0153489Z",
+      "totalMessages": 10,
+      "recentMessages": [
+        {
+          "role": "system",
+          "content": "Don't make assumptions about what values to plug into functions.\r\nAsk for clarification if a user request is ambiguous.",
+        },
+        {
+          "role": "user",
+          "content": "Remind me to call my dad"
+        },
+        {
+          "role": "function",
+          "content": "The function call succeeded. Let the user know that you completed the action.",
+          "name": "AddTodo"
+        },
+        {
+          "role": "assistant",
+          "content": "I have added a reminder for you to call your dad."
+        },
+        {
+          "role": "user",
+          "content": "Oh, and to take out the trash"
+        },
+        {
+          "role": "function",
+          "content": "The function call succeeded. Let the user know that you completed the action.",
+          "name": "AddTodo"
+        },
+        {
+          "role": "assistant",
+          "content": "I have added a reminder for you to take out the trash."
+        },
+        {
+          "role": "user",
+          "content": "What do I need to do today?"
+        },
+        {
+          "role": "function",
+          "content": "[{\"Id\":\"4d3170\",\"Task\":\"Call my dad\"},{\"Id\":\"f1413f\",\"Task\":\"Take out the trash\"}]",
+          "name": "GetTodos"
+        },
+        {
+          "role": "assistant",
+          "content": "Today, you need to:\n- Call your dad\n- Take out the trash"
+        }
+      ]
+    }
+	```
+
+    > **NOTE**: Notice that the list of messages comes from four different roles, `system`, `user`, `assistant`, and `function`. Of these, only messages created by `user` and `assistant` should be displayed to end users. Messages created by `system` and `function` are autoo-generated and should not be displayed.
+
+As you can hopefully see, the assistant acknowledged the two todo items that you created, and then listed them back to you when you asked for your todo list. The interaction effectively looked something like the following:
+
+> **USER**: Remind me to call my dad
+> **ASSISTANT**: I have added a reminder for you to call your dad.
+>
+> **USER**: Oh, and to take out the trash
+> **ASSISTANT**: I have added a reminder for you to take out the trash.
+>
+> **USER**: What do I need to do today?
+> **ASSISTANT**: Today, you need to:
+>  * Call your dad
+>  * Take out the trash
+

--- a/samples/assistant/README.md
+++ b/samples/assistant/README.md
@@ -6,9 +6,8 @@ It builds upon the concepts [chatbot](../chatbot) sample, which demonstrates how
 ## Introduction
 
 AI assistants are chat bots that can be configured with custom skills. Custom skills are implemented using the `assistantSkillTrigger` binding.
-Custom skills are useful ways to extend the functionality of an AI assistant. For example, you can create a custom skill that saves a todo item
-to a database, or a custom skill that queries a database for a list of todo items. In both cases, the skills are defined in your app and any 
-the language model doesn't need to know anything about the skill implementation, making it useful for interacting with private data.
+Custom skills are useful ways to extend the functionality of an AI assistant. For example, you can create a custom skill that saves a todo item to a database, or a custom skill that queries a database for a list of todo items.
+In both cases, the skills are defined in your app and any the language model doesn't need to know anything about the skill implementation, making it useful for interacting with private data.
 
 This OpenAI extension internally uses the [function calling](https://platform.openai.com/docs/guides/function-calling) functionality available in
 `gpt-3.5-turbo` and `gpt-4` models to implement assistant skills.
@@ -26,9 +25,9 @@ public Task AddTodo([AssistantSkillTrigger("Create a new todo task")] string tas
 }
 ```
 
-The `AssistantSkillTrigger` attribute requires a `FunctionDescription` string value, which is text describing what the function does. This is critical
-for the AI assistant to be able to invoke the skill at the right time. The name of the function parameter (e.g., `taskDescription`) is also an important
-hint to the AI assistant about what kind of information to provide to the skill.
+The `AssistantSkillTrigger` attribute requires a `FunctionDescription` string value, which is text describing what the function does.
+This is critical for the AI assistant to be able to invoke the skill at the right time.
+The name of the function parameter (e.g., `taskDescription`) is also an important hint to the AI assistant about what kind of information to provide to the skill.
 
 > **NOTE:** The `AssistantSkillTrigger` attribute only supports primitive types as function parameters, such as `string`, `int`, `bool`, etc. Function return values can be of any JSON-serializable type.
 
@@ -87,7 +86,7 @@ If you want to run the sample with Cosmos DB, then you must also have the follow
     ```http
     PUT http://localhost:7168/api/assistants/assistant123
     ```
-    
+
     > **NOTE:** The `assistant123` value is the unique ID of the assistant. You can use any value you like, but it must be unique and must be used consistently in all subsequent requests.
 
     > **NOTE:** All the HTTP requests in this sample can also be found in the [demo.http](demo.http) file, which can be opened and run in most IDEs.
@@ -104,7 +103,7 @@ If you want to run the sample with Cosmos DB, then you must also have the follow
 
 1. Ask the assistant to create a todo item by sending a `POST` request to the `PostUserQuery` function to send a prompt to the assistant. The following is an example request:
 
-	```http
+    ```http
     POST http://localhost:7168/api/assistants/assistant123
     Content-Type: text/plain
 
@@ -113,44 +112,43 @@ If you want to run the sample with Cosmos DB, then you must also have the follow
 
     The response should be an HTTP 202, indicating that the request was accepted. You should also see some relevant log output in the terminal window where the app is running.
 
-	> **NOTE:** The AI assistant runs asynchronously in the background, so it doesn't respond immediately to prompts.  You should wait for about 10 seconds before sending subsequent messages to the assistant to give it time to finish processing the previous prompt.
+    > **NOTE:** The AI assistant runs asynchronously in the background, so it doesn't respond immediately to prompts.  You should wait for about 10 seconds before sending subsequent messages to the assistant to give it time to finish processing the previous prompt.
 
-	
-	In the function log output, you should observe that the `AddTodo` function was triggered. This function is a custom skill that was automatically registered with the assistant when the app was started.
+    In the function log output, you should observe that the `AddTodo` function was triggered. This function is a custom skill that was automatically registered with the assistant when the app was started.
 
 1. Ask the assistant to create another todo item using another `POST` request to the `PostUserQuery` function. The following is an example request:
 
-	```http
-	POST http://localhost:7168/api/assistants/assistant123
-	Content-Type: text/plain
+    ```http
+    POST http://localhost:7168/api/assistants/assistant123
+    Content-Type: text/plain
 
-	Oh, and to take out the trash
-	```
-    
-	The AI assistant remembers the context from the chat, so it knows that you're still talking about todo items, even if your prompt doesn't mention this explicitly.
+    Oh, and to take out the trash
+    ```
+
+    The AI assistant remembers the context from the chat, so it knows that you're still talking about todo items, even if your prompt doesn't mention this explicitly.
 
 1. If you're running the sample with Cosmos DB persistence configured, then you can use the Cosmos DB Data Explorer to view the documents in the `my-todos` collection in the `testdb` database. You should see two documents, one for each todo item that the assistant created.
 
 1. Ask the assistant to list your todo items by sending a `POST` request to the `PostUserQuery` function. The following is an example request:
 
-  	```http
-	POST http://localhost:7168/api/assistants/assistant123
-	Content-Type: text/plain
+    ```http
+    POST http://localhost:7168/api/assistants/assistant123
+    Content-Type: text/plain
 
-	What do I need to do today?
-	```
+    What do I need to do today?
+    ```
 
-	The response should be an HTTP 202, indicating that the prompt was accepted. In the function log output, you should observe that the `GetTodos` function was triggered. This function is a custom skill that the assistant users to query any previously saved todos.
+    The response should be an HTTP 202, indicating that the prompt was accepted. In the function log output, you should observe that the `GetTodos` function was triggered. This function is a custom skill that the assistant users to query any previously saved todos.
 
 1. Query the chat history by sending a `GET` request to the `GetChatState` function. The following is an example request:
 
-	```http
-	GET http://localhost:7168/api/assistants/assistant123?timestampUTC=2023-01-01T00:00:00Z
-	```
+    ```http
+    GET http://localhost:7168/api/assistants/assistant123?timestampUTC=2023-01-01T00:00:00Z
+    ```
 
-	The response body should look something like the following:
+    The response body should look something like the following:
 
-	```json
+    ```json
     {
       "id": "assistant123",
       "exists": true,
@@ -204,20 +202,23 @@ If you want to run the sample with Cosmos DB, then you must also have the follow
         }
       ]
     }
-	```
+    ```
 
-    > **NOTE**: Notice that the list of messages comes from four different roles, `system`, `user`, `assistant`, and `function`. Of these, only messages created by `user` and `assistant` should be displayed to end users. Messages created by `system` and `function` are autoo-generated and should not be displayed.
+    > **NOTE**: Notice that the list of messages comes from four different roles, `system`, `user`, `assistant`, and `function`. Of these, only messages created by `user` and `assistant` should be displayed to end users. Messages created by `system` and `function` are auto-generated and should not be displayed.
 
 As you can hopefully see, the assistant acknowledged the two todo items that you created, and then listed them back to you when you asked for your todo list. The interaction effectively looked something like the following:
 
 > **USER**: Remind me to call my dad
+>
 > **ASSISTANT**: I have added a reminder for you to call your dad.
 >
 > **USER**: Oh, and to take out the trash
+>
 > **ASSISTANT**: I have added a reminder for you to take out the trash.
 >
 > **USER**: What do I need to do today?
+>
 > **ASSISTANT**: Today, you need to:
->  * Call your dad
->  * Take out the trash
-
+>
+> * Call your dad
+> * Take out the trash

--- a/samples/assistant/csharp-inproc/AssistantApis.cs
+++ b/samples/assistant/csharp-inproc/AssistantApis.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using WebJobs.Extensions.OpenAI.Agents;
+
+namespace AssistantSample;
+
+/// <summary>
+/// Defines HTTP APIs for interacting with assistants.
+/// </summary>
+static class AssistantApis
+{
+    /// <summary>
+    /// HTTP PUT function that creates a new assistant chat bot with the specified ID.
+    /// </summary>
+    [FunctionName(nameof(CreateAssistant))]
+    public static async Task<IActionResult> CreateAssistant(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "assistants/{assistantId}")] HttpRequest req,
+        string assistantId,
+        [ChatBotCreate] IAsyncCollector<ChatBotCreateRequest> createRequests)
+    {
+        string instructions =
+            """
+            Don't make assumptions about what values to plug into functions.
+            Ask for clarification if a user request is ambiguous.
+            """;
+
+        await createRequests.AddAsync(new ChatBotCreateRequest(assistantId, instructions));
+        var responseJson = new { assistantId };
+        return new ObjectResult(responseJson) { StatusCode = 202 };
+    }
+
+    /// <summary>
+    /// HTTP POST function that sends user prompts to the assistant chat bot.
+    /// </summary>
+    [FunctionName(nameof(PostUserQuery))]
+    public static async Task<IActionResult> PostUserQuery(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "assistants/{assistantId}")] HttpRequest req,
+        string assistantId,
+        [ChatBotPost("{assistantId}")] ICollector<ChatBotPostRequest> newMessages)
+    {
+        string userMessage = await req.ReadAsStringAsync();
+        if (string.IsNullOrEmpty(userMessage))
+        {
+            return new BadRequestObjectResult(new { message = "Request body is empty" });
+        }
+
+        newMessages.Add(new ChatBotPostRequest(userMessage));
+        return new AcceptedResult();
+    }
+
+    /// <summary>
+    /// HTTP GET function that queries the conversation history of the assistant chat bot.
+    /// </summary>
+    [FunctionName(nameof(GetChatState))]
+    public static ChatBotState GetChatState(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "assistants/{assistantId}")] HttpRequest req,
+        string assistantId,
+        [ChatBotQuery("{assistantId}", TimestampUtc = "{Query.timestampUTC}")] ChatBotState state)
+    {
+        return state;
+    }
+}

--- a/samples/assistant/csharp-inproc/AssistantSample.csproj
+++ b/samples/assistant/csharp-inproc/AssistantSample.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\README.md" Link="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- OPTIONAL: Replace this with a package reference to CGillum.WebJobs.Extensions.OpenAI -->
+    <ProjectReference Include="..\..\..\src\WebJobs.Extensions.OpenAI\WebJobs.Extensions.OpenAI.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/assistant/csharp-inproc/AssistantSkills.cs
+++ b/samples/assistant/csharp-inproc/AssistantSkills.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using WebJobs.Extensions.OpenAI.Agents;
+
+namespace AssistantSample;
+
+/// <summary>
+/// Defines assistant skills that can be triggered by the assistant chat bot.
+/// </summary>
+public class AssistantSkills
+{
+    readonly ITodoManager todoManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssistantSkills"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This constructor is called by the Azure Functions runtime's dependency injection container.
+    /// </remarks>
+    public AssistantSkills(ITodoManager todoManager)
+    {
+        this.todoManager = todoManager ?? throw new ArgumentNullException(nameof(todoManager));
+    }
+
+    /// <summary>
+    /// Called by the assistant to create new todo tasks.
+    /// </summary>
+    [FunctionName(nameof(AddTodo))]
+    public Task AddTodo([AssistantSkillTrigger("Create a new todo task")] string taskDescription, ILogger log)
+    {
+        if (string.IsNullOrEmpty(taskDescription))
+        {
+            throw new ArgumentException("Task description cannot be empty");
+        }
+
+        log.LogInformation("Adding todo: {task}", taskDescription);
+
+        string todoId = Guid.NewGuid().ToString()[..6];
+        return this.todoManager.AddTodoAsync(new TodoItem(todoId, taskDescription));
+    }
+
+    /// <summary>
+    /// Called by the assistant to fetch the list of previously created todo tasks.
+    /// </summary>
+    [FunctionName(nameof(GetTodos))]
+    public Task<IReadOnlyList<TodoItem>> GetTodos(
+        [AssistantSkillTrigger("Fetch the list of previously created todo tasks")] object inputIgnored,
+        ILogger log)
+    {
+        log.LogInformation("Fetching list of todos");
+
+        return this.todoManager.GetTodosAsync();
+    }
+}

--- a/samples/assistant/csharp-inproc/Properties/launchSettings.json
+++ b/samples/assistant/csharp-inproc/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "AssistantSample": {
+      "commandName": "Project",
+      "commandLineArgs": "--port 7168",
+      "launchBrowser": false
+    }
+  }
+}

--- a/samples/assistant/csharp-inproc/Startup.cs
+++ b/samples/assistant/csharp-inproc/Startup.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: FunctionsStartup(typeof(AssistantSample.Startup))]
+
+namespace AssistantSample;
+
+/// <summary>
+/// Functions startup extension that configures the dependency injection container with an
+/// appropriate implementation of <see cref="ITodoManager"/>.
+/// </summary>
+class Startup : FunctionsStartup
+{
+    public override void Configure(IFunctionsHostBuilder builder)
+    {
+        string? cosmosDbConnectionString = Environment.GetEnvironmentVariable("CosmosDbConnectionString");
+        if (string.IsNullOrEmpty(cosmosDbConnectionString))
+        {
+            // Use an in-memory implementation of ITodoManager if no CosmosDB connection string is provided
+            builder.Services.AddSingleton<ITodoManager, InMemoryTodoManager>();
+        }
+        else
+        {
+            // Use CosmosDB implementation of ITodoManager
+            // Reference: https://learn.microsoft.com/azure/cosmos-db/nosql/best-practice-dotnet#best-practices-for-http-connections
+            SocketsHttpHandler socketsHttpHandler = new()
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            };
+
+            builder.Services.AddSingleton(socketsHttpHandler);
+
+            builder.Services.AddSingleton(serviceProvider =>
+            {
+                SocketsHttpHandler socketsHttpHandler = serviceProvider.GetRequiredService<SocketsHttpHandler>();
+                CosmosClientOptions cosmosClientOptions = new()
+                {
+                    HttpClientFactory = () => new HttpClient(socketsHttpHandler, disposeHandler: false),
+                    SerializerOptions = new CosmosSerializationOptions
+                    {
+                        PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                    }
+                };
+
+                return new CosmosClient(cosmosDbConnectionString, cosmosClientOptions);
+            });
+
+            builder.Services.AddSingleton<ITodoManager, CosmosDbTodoManager>();
+        }
+    }
+}

--- a/samples/assistant/csharp-inproc/TodoManager.cs
+++ b/samples/assistant/csharp-inproc/TodoManager.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace AssistantSample;
+
+/// <summary>
+/// Todo item record which gets stored in the database.
+/// </summary>
+/// <param name="Id">A unique ID for the todo item.</param>
+/// <param name="Task">A description of the task.</param>
+public record TodoItem(string Id, string Task);
+
+/// <summary>
+/// Interface for managing todo items.
+/// </summary>
+public interface ITodoManager
+{
+    /// <summary>
+    /// Adds a new todo item to the database.
+    /// </summary>
+    Task AddTodoAsync(TodoItem todo);
+
+    /// <summary>
+    /// Gets all todo items from the database.
+    /// </summary>
+    Task<IReadOnlyList<TodoItem>> GetTodosAsync();
+}
+
+/// <summary>
+/// Implementation of <see cref="ITodoManager"/> which stores todo items in memory.
+/// </summary>
+/// <remarks>
+/// This implementation is designed to be used when running the function app locally.
+/// </remarks>
+class InMemoryTodoManager : ITodoManager
+{
+    readonly List<TodoItem> todos = new();
+
+    public Task AddTodoAsync(TodoItem todo)
+    {
+        this.todos.Add(todo);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<TodoItem>> GetTodosAsync()
+    {
+        return Task.FromResult<IReadOnlyList<TodoItem>>(this.todos.ToImmutableList());
+    }
+}
+
+/// <summary>
+/// Implementation of <see cref="ITodoManager"/> which stores todo items in Cosmos DB.
+/// </summary>
+/// <remarks>
+/// This implementation can be used in production or when running the function app locally.
+/// This implementation is also suitable for when the app needs to be scaled out or when
+/// the todos need to be persisted even after the function app is recycled.
+/// </remarks>
+class CosmosDbTodoManager : ITodoManager
+{
+    readonly ILogger logger;
+    readonly Container container;
+
+    public CosmosDbTodoManager(ILoggerFactory loggerFactory, CosmosClient cosmosClient)
+    {
+        if (loggerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        if (cosmosClient is null)
+        {
+            throw new ArgumentNullException(nameof(cosmosClient));
+        }
+
+        this.logger = loggerFactory.CreateLogger<CosmosDbTodoManager>();
+        this.container = cosmosClient.GetContainer("testdb", "my-todos");
+    }
+
+    public async Task AddTodoAsync(TodoItem todo)
+    {
+        this.logger.LogInformation("Adding todo ID = {Id} to container '{Container}'.", todo.Id, this.container.Id);
+        await this.container.CreateItemAsync(todo, new PartitionKey(todo.Id));
+    }
+
+    public async Task<IReadOnlyList<TodoItem>> GetTodosAsync()
+    {
+        this.logger.LogInformation("Getting all todos from container '{Container}'.", this.container.Id);
+        FeedIterator<TodoItem> query = this.container.GetItemQueryIterator<TodoItem>(
+            new QueryDefinition("SELECT * FROM c"));
+
+        List<TodoItem> results = new();
+        while (query.HasMoreResults)
+        {
+            FeedResponse<TodoItem> response = await query.ReadNextAsync();
+            results.AddRange(response.Resource);
+        }
+
+        this.logger.LogInformation("Found {Count} todos in container '{Container}'.", results.Count, this.container.Id);
+        return results;
+    }
+}

--- a/samples/assistant/csharp-inproc/demo.http
+++ b/samples/assistant/csharp-inproc/demo.http
@@ -1,0 +1,28 @@
+### Create a new assistant - instructions are hardcoded in the function
+PUT http://localhost:7168/api/assistants/assistant123
+
+
+### Reminder #1
+POST http://localhost:7168/api/assistants/assistant123
+Content-Type: text/plain
+
+Remind me to call my dad
+
+
+### Reminder #2
+POST http://localhost:7168/api/assistants/assistant123
+Content-Type: text/plain
+
+Oh, and to take out the trash
+
+
+### Get the list of tasks
+POST http://localhost:7168/api/assistants/assistant123
+Content-Type: text/plain
+
+What do I need to do today?
+
+
+### Query the chat history
+GET http://localhost:7168/api/assistants/assistant123?timestampUTC=2023-01-01T00:00:00Z
+Accept: application/json

--- a/samples/assistant/csharp-inproc/host.json
+++ b/samples/assistant/csharp-inproc/host.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "WebJobs.Extensions.OpenAI": "Information"
+    }
+  }
+}

--- a/samples/assistant/csharp-inproc/local.settings.json
+++ b/samples/assistant/csharp-inproc/local.settings.json
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    // NOTE: The below is a local CosmosDB Emulator connection string. The account key is NOT a real secret!
+    // IMPORTANT: This file is tracked by source control. Do not use a real secret here! Use environment variables instead to override these settings.
+    // "CosmosDbConnectionString": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;"
+  }
+}

--- a/samples/chat/csharp-inproc/ChatBotSample.csproj
+++ b/samples/chat/csharp-inproc/ChatBotSample.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\demo.http" Link="demo.http" />
+    <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />

--- a/sandbox/OpenAITesting/ChatCompletions.cs
+++ b/sandbox/OpenAITesting/ChatCompletions.cs
@@ -3,9 +3,12 @@
 
 
 using OpenAI;
+using OpenAI.Builders;
 using OpenAI.Managers;
 using OpenAI.ObjectModels;
 using OpenAI.ObjectModels.RequestModels;
+using OpenAI.ObjectModels.ResponseModels;
+using OpenAI.ObjectModels.SharedModels;
 
 namespace OpenAITesting;
 
@@ -18,30 +21,88 @@ static class ChatCompletions
             ApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")!,
         });
 
-        var completionResult = await openAiService.ChatCompletion.CreateCompletion(new ChatCompletionCreateRequest
-        {
-            Messages = new List<ChatMessage>
-            {
-                ChatMessage.FromSystem("You are a helpful assistant."),
-                ChatMessage.FromUser("Who won the world series in 2020?"),
-                ChatMessage.FromAssistant("The Los Angeles Dodgers won the World Series in 2020."),
-                ChatMessage.FromUser("Where was it played?")
-            },
-            Model = Models.Gpt_3_5_Turbo,
-        });
+        FunctionDefinition createTodoFn = new FunctionDefinitionBuilder("AddTodo", "Create a new todo task")
+            .AddParameter("task", PropertyDefinition.DefineString("The task to be created, e.g. take out the garbage"))
+            .Validate()
+            .Build();
 
-        if (completionResult.Successful)
+        FunctionDefinition getTodosFn = new FunctionDefinitionBuilder("GetTodos", "Fetch the list of previously created todo tasks")
+            .Validate()
+            .Build();
+
+        string model = Models.Gpt_4;
+        List<ChatMessage> messages = new()
         {
-            Console.WriteLine(completionResult.Choices.First().Message.Content);
-        }
-        else
+            ChatMessage.FromSystem("Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous."),
+            //ChatMessage.FromUser("What have I accomplished today?")
+            ChatMessage.FromUser("Remind me to call my dad"),
+            //ChatMessage.FromUser("What should I do today?"),
+        };
+
+        Console.WriteLine("USER: " + messages.Last().Content);
+
+        while (true)
         {
-            if (completionResult.Error == null)
+            ChatCompletionCreateResponse completionResult = await openAiService.ChatCompletion.CreateCompletion(
+                new ChatCompletionCreateRequest
+                {
+                    Messages = messages,
+                    Model = model,
+                    Functions = new List<FunctionDefinition> { createTodoFn, getTodosFn },
+                });
+
+            if (!completionResult.Successful)
             {
-                throw new Exception("Unknown Error");
+                if (completionResult.Error is null)
+                {
+                    throw new Exception("Unknown Error");
+                }
+
+                Console.WriteLine($"{completionResult.Error.Code}: {completionResult.Error.Message}");
+                return;
             }
 
-            Console.WriteLine($"{completionResult.Error.Code}: {completionResult.Error.Message}");
+            ChatChoiceResponse choice = completionResult.Choices.First();
+            Console.WriteLine($"Message:        {choice.Message.Content}");
+
+            FunctionCall? fn = choice.Message.FunctionCall;
+            if (fn is null)
+            {
+                break;
+            }
+
+            Console.WriteLine($"Function call:  {fn.Name}");
+            foreach (KeyValuePair<string, object> entry in fn.ParseArguments())
+            {
+                Console.WriteLine($"  {entry.Key}: {entry.Value}");
+            }
+
+            string result;
+            switch (fn.Name)
+            {
+                case "AddTodo":
+                    Console.WriteLine("  Creating todo...");
+                    //result = "The function call executed successfully and returned no results. Let the user know that you completed the action";//"done";
+                    result = "The function call failed. Let the user know and ask if they'd like you to try again";
+                    break;
+                case "GetTodos":
+                    Console.WriteLine("  Fetching todos...");
+                    result = "[\"take out the garbage\", \"call my dad\"]";
+                    break;
+                default:
+                    Console.WriteLine($"  Don't know how to invoke {fn.Name}");
+                    return;
+            }
+
+            Console.WriteLine($"  Result: {result}");
+            if (string.IsNullOrEmpty(result))
+            {
+                break;
+            }
+
+            // Add the result and re-prompt the model
+            messages.Add(ChatMessage.FromFunction(result, fn.Name));
+            continue;
         }
     }
 }

--- a/sandbox/OpenAITesting/OpenAITesting.csproj
+++ b/sandbox/OpenAITesting/OpenAITesting.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Betalgo.OpenAI" Version="7.3.0" />
+    <PackageReference Include="Betalgo.OpenAI" Version="7.4.0" />
   </ItemGroup>
 
 </Project>

--- a/sandbox/OpenAITesting/Program.cs
+++ b/sandbox/OpenAITesting/Program.cs
@@ -6,6 +6,9 @@ using OpenAI.Managers;
 using OpenAI.ObjectModels;
 using OpenAI.ObjectModels.RequestModels;
 using OpenAI.ObjectModels.ResponseModels;
+using OpenAITesting;
+
+await ChatCompletions.Run();
 
 OpenAIService openAiService = new(new OpenAiOptions()
 {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,12 +15,13 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Chris Gillum</Authors>
+    <PackageTags>Azure Functions Extension OpenAI AI LLM ChatBot Assistant Embeddings Search</PackageTags>
   </PropertyGroup>
 
     <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>4</MinorVersion>
+    <MinorVersion>5</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>

--- a/src/WebJobs.Extensions.OpenAI.Kusto/WebJobs.Extensions.OpenAI.Kusto.csproj
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/WebJobs.Extensions.OpenAI.Kusto.csproj
@@ -1,12 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Title>Azure Functions OpenAI Kusto Extension</Title>
+    <Description>Kusto Vector DB provider for OpenAI semantic search Azure Functions bindings</Description>
+    <PackageTags>$(PackageTags) WebJobs Kusto</PackageTags>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\WebJobs.Extensions.OpenAI\WebJobs.Extensions.OpenAI.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.2" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.2" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.5" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.5" />
   </ItemGroup>
 </Project>

--- a/src/WebJobs.Extensions.OpenAI/Agents/AssistantSkillTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/AssistantSkillTriggerAttribute.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.WebJobs.Description;
+
+namespace WebJobs.Extensions.OpenAI.Agents;
+
+[Binding]
+[AttributeUsage(AttributeTargets.Parameter)]
+public class AssistantSkillTriggerAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssistantSkillTriggerAttribute"/> class with the specified function
+    /// description.
+    /// </summary>
+    /// <param name="functionDescription">A description of the assistant function, which is provided to the model.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="functionDescription"/> is <c>null</c>.</exception>
+    public AssistantSkillTriggerAttribute(string functionDescription)
+    {
+        this.FunctionDescription = functionDescription ?? throw new ArgumentNullException(nameof(functionDescription));
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the function to be invoked by the assistant.
+    /// </summary>
+    public string? FunctionName { get; set;  }
+
+    /// <summary>
+    /// Gets the description of the assistant function, which is provided to the LLM.
+    /// </summary>
+    public string FunctionDescription { get; }
+
+    // TODO: Consider making the function description another trigger type to make it work across all languages
+
+    /// <summary>
+    /// Gets or sets a description of the function parameter, which is provided to the LLM.
+    /// </summary>
+    public string? ParameterDescription { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OpenAI chat model to use.
+    /// </summary>
+    /// <remarks>
+    /// When using Azure OpenAI, then should be the name of the model <em>deployment</em>.
+    /// </remarks>
+    public string Model { get; set; } = "gpt-3.5-turbo";
+}

--- a/src/WebJobs.Extensions.OpenAI/Agents/AssistantSkillTriggerBindingProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/AssistantSkillTriggerBindingProvider.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Newtonsoft.Json.Linq;
+
+namespace WebJobs.Extensions.OpenAI.Agents;
+
+class AssistantSkillTriggerBindingProvider : ITriggerBindingProvider
+{
+    static readonly Task<ITriggerBinding?> NullTriggerBindingTask = Task.FromResult<ITriggerBinding?>(null);
+
+    readonly INameResolver nameResolver;
+    readonly AssistantSkillManager skillManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssistantSkillTriggerBindingProvider"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This constructor is called by the dependency management container in the Functions (WebJobs) runtime.
+    /// </remarks>
+    public AssistantSkillTriggerBindingProvider(INameResolver nameResolver, AssistantSkillManager skillManager)
+    {
+        this.nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
+        this.skillManager = skillManager;
+    }
+
+    public Task<ITriggerBinding?> TryCreateAsync(TriggerBindingProviderContext context)
+    {
+        // The function trigger parameter must have AssistantTriggerAttribute
+        ParameterInfo parameter = context.Parameter;
+        AssistantSkillTriggerAttribute? attribute = parameter.GetCustomAttribute<AssistantSkillTriggerAttribute>();
+        if (attribute is null)
+        {
+            return NullTriggerBindingTask;
+        }
+
+        string functionName = GetFunctionName(parameter, this.nameResolver, attribute.FunctionName);
+        ITriggerBinding binding = new AssistantTriggerBinding(
+            functionName,
+            attribute,
+            parameter,
+            this.skillManager);
+        return Task.FromResult(binding)!;
+    }
+
+    /// <summary>
+    /// Gets the appropriate name of the assistant function.
+    /// </summary>
+    static string GetFunctionName(ParameterInfo parameter, INameResolver nameResolver, string? triggerName)
+    {
+        if (triggerName is null)
+        {
+            MemberInfo method = parameter.Member;
+            return method.GetCustomAttribute<FunctionNameAttribute>()?.Name ?? method.Name;
+        }
+        else if (nameResolver.TryResolveWholeString(triggerName, out string? resolvedTriggerName))
+        {
+            return resolvedTriggerName;
+        }
+        else
+        {
+            return triggerName;
+        }
+    }
+
+    class AssistantTriggerBinding : ITriggerBinding
+    {
+        readonly string skillName;
+        readonly AssistantSkillTriggerAttribute attribute;
+        readonly ParameterInfo parameterInfo;
+        readonly AssistantSkillManager skillManager;
+
+        public AssistantTriggerBinding(
+            string skillName,
+            AssistantSkillTriggerAttribute attribute,
+            ParameterInfo parameterInfo,
+            AssistantSkillManager skillManager)
+        {
+            this.skillName = skillName ?? throw new ArgumentNullException(nameof(skillName));
+            this.attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
+            this.parameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
+            this.skillManager = skillManager ?? throw new ArgumentNullException(nameof(skillManager));
+        }
+
+        public Type TriggerValueType => typeof(string);
+
+        public IReadOnlyDictionary<string, Type> BindingDataContract { get; } =
+            new Dictionary<string, Type>
+            {
+                { "$return", typeof(object).MakeByRefType() },
+            };
+
+        public ParameterDescriptor ToParameterDescriptor()
+        {
+            return new ParameterDescriptor
+            {
+                Name = this.parameterInfo.Name,
+                Type = this.parameterInfo.ParameterType.Name,
+            };
+        }
+
+        /// <summary>
+        /// Converts the trigger value (from the OpenAI model) into the type of the function trigger parameter.
+        /// NOTE: Need to review whether this logic will work correctly for out-of-proc languages.
+        /// </summary>
+        public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+        {
+            Type destinationType = this.parameterInfo.ParameterType;
+
+            // We expect that input to always be a string value in the form {"paramName":paramValue}
+            string argumentsText = (string)value;
+
+            object? convertedValue;
+            if (!string.IsNullOrEmpty(argumentsText))
+            {
+                JObject argsJson = JObject.Parse(argumentsText);
+                JToken? paramValue = argsJson[this.parameterInfo.Name] ?? 
+                    throw new InvalidOperationException($"The parameter '{this.parameterInfo.Name}' was not found in the arguments.");
+                convertedValue = paramValue.ToObject(destinationType);
+            }
+            else
+            {
+                // Value types in .NET can't be assigned to null, so we use Activator.CreateInstance to 
+                // create a default value of the type (example, 0 for int).
+                convertedValue = destinationType.IsValueType ? Activator.CreateInstance(destinationType) : null;
+            }
+
+            SimpleValueProvider inputValueProvider = new(convertedValue, destinationType);
+
+            Dictionary<string, object?> bindingData = new(StringComparer.OrdinalIgnoreCase); // TODO: Cache
+            TriggerData triggerData = new(inputValueProvider, bindingData);
+            return Task.FromResult<ITriggerData>(triggerData);
+        }
+
+        public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+        {
+            IListener listener = new AssistantTriggerListener(
+                this.skillName,
+                this.attribute,
+                this.parameterInfo,
+                context,
+                this.skillManager);
+            return Task.FromResult(listener);
+        }
+
+        class SimpleValueProvider : IValueProvider
+        {
+            readonly object? value;
+            readonly Task<object?> valueAsTask;
+            readonly Type valueType;
+
+            public SimpleValueProvider(object? value, Type valueType)
+            {
+                if (value is not null && !valueType.IsAssignableFrom(value.GetType()))
+                {
+                    throw new ArgumentException($"Cannot convert {value} to {valueType.Name}.");
+                }
+
+                this.value = value;
+                this.valueAsTask = Task.FromResult(value);
+                this.valueType = valueType;
+            }
+
+            public Type Type
+            {
+                get { return this.valueType; }
+            }
+
+            public Task<object?> GetValueAsync()
+            {
+                return this.valueAsTask;
+            }
+
+            public string? ToInvokeString()
+            {
+                return this.value?.ToString();
+            }
+        }
+
+        class AssistantTriggerListener : IListener
+        {
+            readonly string skillName;
+            readonly AssistantSkillTriggerAttribute attribute;
+            readonly ParameterInfo parameterInfo;
+            readonly ListenerFactoryContext context;
+            readonly AssistantSkillManager skillManager;
+
+            public AssistantTriggerListener(
+                string skillName,
+                AssistantSkillTriggerAttribute attribute,
+                ParameterInfo parameterInfo,
+                ListenerFactoryContext context,
+                AssistantSkillManager skillManager)
+            {
+                this.skillName = skillName;
+                this.attribute = attribute;
+                this.parameterInfo = parameterInfo;
+                this.context = context;
+                this.skillManager = skillManager;
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                this.skillManager.RegisterSkill(
+                    this.skillName,
+                    this.attribute,
+                    this.parameterInfo,
+                    this.context.Executor);
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                this.skillManager.UnregisterSkill(this.skillName);
+                return Task.CompletedTask;
+            }
+
+            public void Cancel()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.OpenAI/Agents/ChatBotEntity.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/ChatBotEntity.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -51,12 +47,17 @@ class ChatBotEntity : IChatBotEntity
 {
     readonly ILogger logger;
     readonly IOpenAIServiceProvider openAIServiceProvider;
+    readonly IAssistantSkillInvoker skillInvoker;
 
-    public ChatBotEntity(ILoggerFactory loggerFactory, IOpenAIServiceProvider openAIServiceProvider)
+    public ChatBotEntity(
+        ILoggerFactory loggerFactory,
+        IOpenAIServiceProvider openAIServiceProvider,
+        IAssistantSkillInvoker skillInvoker)
     {
         // When initialized via dependency injection
         this.logger = loggerFactory.CreateLogger<ChatBotEntity>();
         this.openAIServiceProvider = openAIServiceProvider ?? throw new ArgumentNullException(nameof(openAIServiceProvider));
+        this.skillInvoker = skillInvoker ?? throw new ArgumentNullException(nameof(skillInvoker));
     }
 
     [JsonConstructor]
@@ -65,6 +66,7 @@ class ChatBotEntity : IChatBotEntity
         // For deserialization
         this.logger = null!;
         this.openAIServiceProvider = null!;
+        this.skillInvoker = null!;
     }
 
     [JsonProperty("state")]
@@ -105,41 +107,120 @@ class ChatBotEntity : IChatBotEntity
 
         this.State.ChatMessages ??= new List<MessageRecord>();
         this.State.ChatMessages.Add(new(DateTime.UtcNow, ChatMessage.FromUser(request.UserMessage)));
-        
-        // Get the next response from the LLM
-        ChatCompletionCreateRequest chatRequest = new()
-        {
-            Messages = this.State.ChatMessages.Select(item => item.Message).ToList(),
-            Model = request.Model ?? Models.Gpt_3_5_Turbo,
-        };
 
-        IOpenAIService service = this.openAIServiceProvider.GetService(chatRequest.Model);
-        ChatCompletionCreateResponse response = await service.ChatCompletion.CreateCompletion(chatRequest);
-        if (!response.Successful)
+        string modelOrDeployment = request.Model ?? Models.Gpt_3_5_Turbo;
+        IOpenAIService service = this.openAIServiceProvider.GetService(modelOrDeployment);
+
+        // We loop if the model returns function calls. Otherwise, we break right away.
+        // TODO: Add protection against infinite loops, which could happen if the model
+        //       always returns function calls. We could add a limit on the number of
+        //       loops, or a timeout, or both. We could also add a limit on the number
+        //       of tokens returned by the model, which would prevent a runnaway billing
+        //       situation.
+        while (true)
         {
-            // Throwing an exception will cause the entity to abort the current operation.
-            // Any changes to the entity state will be discarded.
-            Error error = response.Error ?? new Error() { Code = "Unspecified", MessageObject = "Unspecified error" };
-            throw new ApplicationException($"The OpenAI {chatRequest.Model} engine returned a '{error.Code}' error: {error.Message}");
+            // Get the next response from the LLM
+            ChatCompletionCreateRequest chatRequest = new()
+            {
+                Messages = this.State.ChatMessages.Select(item => item.Message).ToList(),
+                Model = modelOrDeployment,
+                Functions = this.skillInvoker.GetFunctionsDefinitions(),
+            };
+
+            ChatCompletionCreateResponse response = await service.ChatCompletion.CreateCompletion(chatRequest);
+            if (!response.Successful)
+            {
+                // Throwing an exception will cause the entity to abort the current operation.
+                // Any changes to the entity state will be discarded.
+                Error error = response.Error ?? new Error() { Code = "Unspecified", MessageObject = "Unspecified error" };
+                throw new ApplicationException($"The OpenAI {chatRequest.Model} engine returned a '{error.Code}' error: {error.Message}");
+            }
+
+            // We don't normally expect more than one message, but just in case we get multiple messages,
+            // return all of them separated by two newlines.
+            string replyMessage = string.Join(
+                Environment.NewLine + Environment.NewLine,
+                response.Choices.Select(choice => choice.Message.Content));
+
+            this.logger.LogInformation(
+                "[{Id}] Got LLM response consisting of {Count} tokens: {Text}",
+                Entity.Current.EntityId,
+                response.Usage.CompletionTokens,
+                replyMessage);
+
+            if (!string.IsNullOrWhiteSpace(replyMessage))
+            {
+                this.State.ChatMessages.Add(new(DateTime.UtcNow, ChatMessage.FromAssistant(replyMessage.Trim())));
+
+                this.logger.LogInformation(
+                    "[{Id}] Chat length is now {Count} messages",
+                    Entity.Current.EntityId,
+                    this.State.ChatMessages.Count);
+            }
+
+            // Check for function calls
+            List<FunctionCall> functionCalls = response.Choices
+                .Select(c => c.Message.FunctionCall!)
+                .Where(f => f is not null)
+                .ToList();
+            if (functionCalls.Count == 0)
+            {
+                // No function calls, so we're done
+                break;
+            }
+
+            // Loop case: found some functions to execute
+            this.logger.LogInformation(
+                "[{Id}] Found {Count} function call(s) in response",
+                Entity.Current.EntityId,
+                functionCalls.Count);
+
+            // Invoke the function calls and add the responses to the chat history.
+            List<Task<object>> tasks = new(capacity: functionCalls.Count);
+            foreach (FunctionCall call in functionCalls)
+            {
+                // CONSIDER: Call these in parallel
+                this.logger.LogInformation(
+                    "[{Id}] Calling function '{Name}' with arguments: {Args}",
+                    Entity.Current.EntityId,
+                    call.Name,
+                    call.Arguments);
+
+                string? result;
+                try
+                {
+                    // NOTE: In Consumption plans, calling a function from another function results in double-billing.
+                    // CONSIDER: Use a background thread to invoke the action to avoid double-billing.
+                    result = await this.skillInvoker.InvokeAsync(call);
+
+                    this.logger.LogInformation(
+                        "[{id}] Function '{Name}' returned the following content: {Content}",
+                        Entity.Current.EntityId,
+                        call.Name,
+                        result);
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogError(
+                        ex,
+                        "[{id}] Function '{Name}' failed with an unhandled exception",
+                        Entity.Current.EntityId);
+
+                    // CONSIDER: Automatic retries?
+                    result = "The function call failed. Let the user know and ask if they'd like you to try again";
+                }
+
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    // When experimenting with gpt-4-0613, an empty result would cause the model to go into a
+                    // function calling loop. By instead providing a result with some instructions, I was able
+                    // to get the model to response to the user in a natural way.
+                    result = "The function call succeeded. Let the user know that you completed the action.";
+                }
+
+                ChatMessage funcMessage = ChatMessage.FromFunction(result, call.Name);
+                this.State.ChatMessages.Add(new(DateTime.UtcNow, funcMessage));
+            }
         }
-
-        // We don't normally expect more than one message, but just in case we get multiple messages,
-        // return all of them separated by two newlines.
-        string replyMessage = string.Join(
-            Environment.NewLine + Environment.NewLine,
-            response.Choices.Select(choice => choice.Message.Content));
-
-        this.logger.LogInformation(
-            "[{Id}] Got LLM response consisting of {Count} tokens: {Text}",
-            Entity.Current.EntityId,
-            response.Usage.CompletionTokens,
-            replyMessage);
-        
-        this.State.ChatMessages.Add(new(DateTime.UtcNow, ChatMessage.FromAssistant(replyMessage)));
-
-        this.logger.LogInformation(
-            "[{Id}] Chat length is now {Count} messages",
-            Entity.Current.EntityId,
-            this.State.ChatMessages.Count);
     }
 }

--- a/src/WebJobs.Extensions.OpenAI/Agents/IAssistantSkillInvoker.cs
+++ b/src/WebJobs.Extensions.OpenAI/Agents/IAssistantSkillInvoker.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using OpenAI.Builders;
+using OpenAI.ObjectModels.RequestModels;
+using OpenAI.ObjectModels.SharedModels;
+
+namespace WebJobs.Extensions.OpenAI.Agents;
+
+public interface IAssistantSkillInvoker
+{
+    IList<FunctionDefinition>? GetFunctionsDefinitions();
+    Task<string?> InvokeAsync(FunctionCall call);
+}
+
+public class AssistantSkillManager : IAssistantSkillInvoker
+{
+    record Skill(
+        string Name,
+        AssistantSkillTriggerAttribute Attribute,
+        ParameterInfo Parameter,
+        ITriggeredFunctionExecutor Executor);
+
+    readonly IApplicationLifetime hostLifetime;
+    readonly ILogger logger;
+
+    readonly Dictionary<string, Skill> skills = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssistantSkillManager"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This constructor is called by the dependency management container in the Functions (WebJobs) runtime.
+    /// </remarks>
+    public AssistantSkillManager(IApplicationLifetime hostLifetime, ILoggerFactory loggerFactory)
+    {
+        this.hostLifetime = hostLifetime;
+        this.logger = loggerFactory.CreateLogger<AssistantSkillManager>();
+    }
+
+    internal void RegisterSkill(
+        string name,
+        AssistantSkillTriggerAttribute attribute,
+        ParameterInfo parameter,
+        ITriggeredFunctionExecutor executor)
+    {
+        this.logger.LogInformation("Registering skill '{Name}'", name);
+        this.skills.Add(name, new Skill(name, attribute, parameter, executor));
+    }
+
+    internal void UnregisterSkill(string name)
+    {
+        this.logger.LogInformation("Unregistering skill '{Name}'", name);
+        this.skills.Remove(name);
+    }
+
+    IList<FunctionDefinition>? IAssistantSkillInvoker.GetFunctionsDefinitions()
+    {
+        if (this.skills.Count == 0)
+        {
+            return null;
+        }
+
+        List<FunctionDefinition> functions = new(capacity: this.skills.Count);
+        foreach (Skill skill in this.skills.Values)
+        {
+            FunctionDefinition definition = new FunctionDefinitionBuilder(skill.Name, skill.Attribute.FunctionDescription)
+                .AddParameter(skill.Parameter.Name, GetParameterDefinition(skill))
+                .Validate()
+                .Build();
+            functions.Add(definition);
+        }
+
+        return functions;
+    }
+
+    static PropertyDefinition GetParameterDefinition(Skill skill)
+    {
+        ////// First, consider the declared type of the skill, if any
+        ////if (!string.IsNullOrEmpty(skill.Attribute.ParameterType))
+        ////{
+
+        ////}
+
+        // Next, try to infer from the .NET parameter type (only works with in-proc WebJobs)
+        switch (skill.Parameter.ParameterType)
+        {
+            case Type type when type == typeof(string):
+                return PropertyDefinition.DefineString(skill.Attribute.ParameterDescription);
+            case Type type when type == typeof(int):
+                return PropertyDefinition.DefineInteger(skill.Attribute.ParameterDescription);
+            case Type type when type == typeof(bool):
+                return PropertyDefinition.DefineBoolean(skill.Attribute.ParameterDescription);
+            case Type type when type == typeof(float):
+                return PropertyDefinition.DefineNumber(skill.Attribute.ParameterDescription);
+            case Type type when type == typeof(double):
+                return PropertyDefinition.DefineNumber(skill.Attribute.ParameterDescription);
+            case Type type when type == typeof(decimal):
+                return PropertyDefinition.DefineNumber(skill.Attribute.ParameterDescription);
+            case Type _ when typeof(System.Collections.IEnumerable).IsAssignableFrom(skill.Parameter.ParameterType):
+                return PropertyDefinition.DefineArray();
+            default:
+                return PropertyDefinition.DefineString(skill.Attribute.ParameterDescription);
+        }
+    }
+
+    async Task<string?> IAssistantSkillInvoker.InvokeAsync(FunctionCall call)
+    {
+        if (call is null)
+        {
+            throw new ArgumentNullException(nameof(call));
+        }
+
+        if (call.Name is null)
+        {
+            throw new ArgumentException("The function call must have a name", nameof(call));
+        }
+
+        if (!this.skills.TryGetValue(call.Name, out Skill? skill))
+        {
+            throw new InvalidOperationException($"No skill registered with name '{call.Name}'");
+        }
+
+        // This call may throw if the Functions host is shutting down or if there is an internal error
+        // in the Functions runtime. We don't currently try to handle these exceptions.
+        object? skillOutput = null;
+        FunctionResult result = await skill.Executor.TryExecuteAsync(
+            new TriggeredFunctionData
+            {
+                TriggerValue = call.Arguments,
+#pragma warning disable CS0618 // Approved for use by this extension
+                InvokeHandler = async userCodeInvoker =>
+                {
+                    // We yield control to ensure this code is executed asynchronously relative to WebJobs.
+                    // This ensures WebJobs is able to correctly cancel the invocation in the case of a timeout.
+                    await Task.Yield();
+
+                    // Invoke the function and attempt to get the result.
+                    this.logger.LogInformation("Invoking user-code function '{Name}'", call.Name);
+                    Task invokeTask = userCodeInvoker.Invoke();
+                    if (invokeTask is not Task<object> resultTask)
+                    {
+                        throw new InvalidOperationException(
+                            "The WebJobs runtime returned a invocation task that does not support return values!");
+                    }
+
+                    skillOutput = await resultTask;
+                }
+#pragma warning restore CS0618
+            },
+            this.hostLifetime.ApplicationStopping);
+
+        // If the function threw an exception, rethrow it here. This will cause the caller (e.g., the
+        // chat bot entity) to receive an error response, which it should be prepared to catch and handle.
+        if (result.Exception is not null)
+        {
+            ExceptionDispatchInfo.Throw(result.Exception);
+        }
+
+        if (skillOutput is null)
+        {
+            return null;
+        }
+
+        // Convert the output to JSON
+        string jsonResult = JsonConvert.SerializeObject(skillOutput);
+        this.logger.LogInformation(
+            "Returning output of user-code function '{Name}' as JSON: {Json}", call.Name, jsonResult);
+        return jsonResult;
+    }
+}

--- a/src/WebJobs.Extensions.OpenAI/OpenAIExtension.cs
+++ b/src/WebJobs.Extensions.OpenAI/OpenAIExtension.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Newtonsoft.Json.Linq;
@@ -20,19 +19,22 @@ partial class OpenAIExtension : IExtensionConfigProvider
     readonly EmbeddingsConverter embeddingsConverter;
     readonly SemanticSearchConverter semanticSearchConverter;
     readonly ChatBotBindingConverter chatBotConverter;
+    readonly AssistantSkillTriggerBindingProvider assistantskillTriggerBindingProvider;
 
     public OpenAIExtension(
         IOpenAIService service,
         TextCompletionConverter textCompletionConverter,
         EmbeddingsConverter embeddingsConverter,
         SemanticSearchConverter semanticSearchConverter,
-        ChatBotBindingConverter chatBotConverter)
+        ChatBotBindingConverter chatBotConverter,
+        AssistantSkillTriggerBindingProvider assistantTriggerBindingProvider)
     {
         this.service = service ?? throw new ArgumentNullException(nameof(service));
         this.textCompletionConverter = textCompletionConverter ?? throw new ArgumentNullException(nameof(textCompletionConverter));
         this.embeddingsConverter = embeddingsConverter ?? throw new ArgumentNullException(nameof(embeddingsConverter));
         this.semanticSearchConverter = semanticSearchConverter ?? throw new ArgumentNullException(nameof(semanticSearchConverter));
         this.chatBotConverter = chatBotConverter ?? throw new ArgumentNullException(nameof(chatBotConverter));
+        this.assistantskillTriggerBindingProvider = assistantTriggerBindingProvider ?? throw new ArgumentNullException(nameof(assistantTriggerBindingProvider));
     }
 
     void IExtensionConfigProvider.Initialize(ExtensionConfigContext context)
@@ -67,6 +69,10 @@ partial class OpenAIExtension : IExtensionConfigProvider
         var chatBotQueryRule = context.AddBindingRule<ChatBotQueryAttribute>();
         chatBotQueryRule.BindToInput<ChatBotState>(this.chatBotConverter);
         chatBotQueryRule.BindToInput<string>(this.chatBotConverter);
+
+        // Assistant skill trigger support
+        context.AddBindingRule<AssistantSkillTriggerAttribute>()
+            .BindToTrigger(this.assistantskillTriggerBindingProvider);
 
         // OpenAI service input binding support (NOTE: This may be removed in a future version.)
         context.AddBindingRule<OpenAIServiceAttribute>().BindToInput(_ => this.service);

--- a/src/WebJobs.Extensions.OpenAI/OpenAIWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.OpenAI/OpenAIWebJobsBuilderExtensions.cs
@@ -72,6 +72,10 @@ public static class OpenAIWebJobsBuilderExtensions
         builder.Services.AddSingleton<EmbeddingsConverter>();
         builder.Services.AddSingleton<SemanticSearchConverter>();
         builder.Services.AddSingleton<ChatBotBindingConverter>();
+        builder.Services
+            .AddSingleton<AssistantSkillManager>()
+            .AddSingleton<IAssistantSkillInvoker>(p => p.GetRequiredService<AssistantSkillManager>());
+        builder.Services.AddSingleton<AssistantSkillTriggerBindingProvider>();
         builder.Services.AddSingleton<IChatBotService, DefaultChatBotService>();
 
         return builder;

--- a/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
+++ b/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
@@ -1,5 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <Title>Azure Functions OpenAI Extension</Title>
+    <Description>Azure Functions and Azure WebJobs SDK extension for OpenAI</Description>
+    <PackageTags>$(PackageTags) WebJobs</PackageTags>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />


### PR DESCRIPTION
This PR adds support for "assistants" - i.e., chat bots that can invoke functions as custom skills.

To support assistants, a new `AssistantSkillTrigger` is introduced. Any such functions in your project become automatically callable by chat bots. A sample demonstrating this is also included in the PR.

As part of this change, whenever a prompt is sent to a chat bot, the list of `AssistantSkillTrigger` functions are sent to the GPT language model. The model can then decide to respond by invoking one of those functions, which is done by the updated entity logic. The response is then sent back to the model so that it can respond to the user prompt appropriately.

Some additional high-level improvements to be considered for this functionality:

* Make it possible to configure which skills can be invoked by which assistants (right now, all bots can call any skill).
* Support marking certain skills as "requiring user confirmation" and then having the bot request permission before invoking that skill.
* Support defining functions with complex parameter types (only primitive types are currently supported)

As with chat bots, it's unfortunately not yet possible to use this with .NET Isolated until https://github.com/cgillum/azure-functions-openai-extension/issues/21 is fixed.