### PR TITLE
Fix dotnet ooproc TextCompletion example

### DIFF
--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/CSharpIsolatedSamples.csproj
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/CSharpIsolatedSamples.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/TextCompletions.cs
+++ b/samples/other/dotnet/csharp-ooproc/CSharpIsolatedSamples/TextCompletions.cs
@@ -4,8 +4,11 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using OpenAI.ObjectModels.ResponseModels;
+using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
 
 namespace CSharpIsolatedSamples;
+
+
 
 /// <summary>
 /// These samples show how to use the OpenAI Completions APIs. For more details on the Completions APIs, see
@@ -26,22 +29,23 @@ public static class TextCompletions
     }
 
     /// <summary>
-    /// This sample takes a prompt as input, sends it directly to the OpenAI completions API, and results the 
+    /// This sample takes a prompt as input, sends it directly to the OpenAI completions API, and results the
     /// response as the output.
     /// </summary>
     [Function(nameof(GenericCompletion))]
     public static IActionResult GenericCompletion(
-        [HttpTrigger(AuthorizationLevel.Function, "post")] PromptPayload payload,
+        [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req,
+        [FromBody] PromptPayload payload,
         [TextCompletionInput("{Prompt}", Model = "text-davinci-003")] CompletionCreateResponse response,
-        ILogger log)
+        FunctionContext executionContext)
     {
+        ILogger logger = executionContext.GetLogger(nameof(GenericCompletion));
         if (!response.Successful)
         {
             Error error = response.Error ?? new Error() { MessageObject = "OpenAI returned an unspecified error" };
             return new ObjectResult(error) { StatusCode = 500 };
         }
-
-        log.LogInformation("Prompt = {prompt}, Response = {response}", payload.Prompt, response);
+        logger.LogInformation("Prompt = {Prompt}, Response = {response}", payload.Prompt, response);
         string text = response.Choices[0].Text;
         return new OkObjectResult(text);
     }


### PR DESCRIPTION
GenericCompletion example throw exception like below image.
<img width="695" alt="image" src="https://github.com/cgillum/azure-functions-openai-extension/assets/1381907/a6a107e9-2494-46b7-b883-50eebe46c4fe">

